### PR TITLE
update promesa, adapting to breaking api changes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [binaryage/devtools "0.8.2"]
                  [keechma "0.3.13" :exclusions [cljsjs/react-with-addons]]
                  [garden "1.3.2"]
-                 [funcool/promesa "1.8.1"]
+                 [funcool/promesa "5.1.0"]
                  [keechma/forms "0.1.2"]
                  [medley "0.8.4"]
                  [cljs-ajax "0.5.8"]

--- a/src/cljs/keechma/toolbox/ajax.cljs
+++ b/src/cljs/keechma/toolbox/ajax.cljs
@@ -8,10 +8,10 @@
 
 (defn promisify [method]
   (fn [url opts]
-    (p/promise
-     (fn [resolve reject on-cancel]
-       (let [r (method url (merge opts {:handler resolve :error-handler (make-error-handler reject)}))]
-         (when (fn? on-cancel) (on-cancel #(ajax/abort r))))))))
+    (p/create
+     (fn [resolve reject]
+       (method url (merge opts {:handler resolve
+                                :error-handler (make-error-handler reject)}))))))
 
 (def GET (promisify ajax/GET))
 (def HEAD (promisify ajax/HEAD))

--- a/src/cljs/keechma/toolbox/dataloader/controller.cljs
+++ b/src/cljs/keechma/toolbox/dataloader/controller.cljs
@@ -107,7 +107,7 @@ Dataloader can be manually triggered by sending the `:load-data` command to the 
  ([data]
   (fn [params]
     (map (fn [loader-params]
-           (p/promise (fn [resolve reject]
+           (p/create (fn [resolve reject]
                         (let [value (or data (:params loader-params))]
                           (js/setTimeout #(resolve value) 1)))))
          params))))

--- a/src/cljs/keechma/toolbox/tasks.cljs
+++ b/src/cljs/keechma/toolbox/tasks.cljs
@@ -146,7 +146,7 @@
   ([producer id reducer ctrl app-db-atom value]
    (blocking-task-producer producer id reducer ctrl app-db-atom value nil))
   ([producer id reducer ctrl app-db-atom value pipelines$]
-   (p/promise (fn [resolve reject]
+   (p/create (fn [resolve reject]
                 (task-loop {:reducer reducer
                             :producer producer
                             :ctrl ctrl

--- a/test/cljs/keechma/toolbox/dataloader_test.cljs
+++ b/test/cljs/keechma/toolbox/dataloader_test.cljs
@@ -20,7 +20,7 @@
   ([data]
    (fn [params]
      (map (fn [loader-params]
-            (p/promise (fn [resolve reject]
+            (p/create (fn [resolve reject]
                          (let [value (or data (:params loader-params))]
                            (js/setTimeout #(resolve value) 1)))))
           params))))
@@ -121,7 +121,7 @@
     :deps   [:jwt]
     :loader (fn [params]
               (map (fn [_]
-                     (p/promise (fn [_ reject]
+                     (p/create (fn [_ reject]
                                   (js/setTimeout #(reject error-404) 1)))) params))}
 
    :current-user-favorites
@@ -429,7 +429,7 @@
                     (map (fn [r]
                            (when-let [params (:params r)]
                              (swap! tracking-atom inc)
-                             (p/promise (fn [resolve reject]
+                             (p/create (fn [resolve reject]
                                           (js/setTimeout #(resolve {:some :data}) 10)))))
                          reqs))
           :params (fn [_ _ _]
@@ -596,7 +596,7 @@
                     (map (fn [r]
                            (let [u-delay (or (get-in r [:params :delay]) 0)
                                  user (get-in r [:params :user])]
-                             (p/promise (fn [resolve reject]
+                             (p/create (fn [resolve reject]
                                           (js/setTimeout
                                            (fn []
                                              (swap! log conj user)
@@ -616,7 +616,7 @@
            (->> (dataloader app-db-atom)
                 (p/map (fn []
                          (is (= 2 (get-in @app-db-atom [:kv :user])))
-                         (p/promise (fn [resolve reject]
+                         (p/create (fn [resolve reject]
                                       (js/setTimeout resolve 100)))))
                 (p/map (fn []
                          (is (= [2 1] @log))
@@ -631,7 +631,7 @@
                       (map (fn [r]
                              (let [u-delay (or (get-in r [:params :user-delay]) 0)
                                    user (get-in r [:params :user])]
-                               (p/promise (fn [resolve reject]
+                               (p/create (fn [resolve reject]
                                             (js/setTimeout
                                              (fn []
                                                (swap! log conj user)
@@ -645,7 +645,7 @@
                                  (swap! product-id inc)
                                  (let [p-delay (or (get-in r [:params :product-delay]) 0)
                                        product {:id @product-id :user (get-in r [:params :user])}]
-                                   (p/promise (fn [resolve reject]
+                                   (p/create (fn [resolve reject]
                                                 (js/setTimeout
                                                  (fn []
                                                    (swap! log conj product)
@@ -662,7 +662,7 @@
          (p/error (fn [])))
     (async done
            
-           (->> (p/promise (fn [resolve reject]
+           (->> (p/create (fn [resolve reject]
                              (js/setTimeout
                               (fn []
                                 (swap! app-db-atom assoc-in [:route :data] {:user-delay 0 :product-delay 0 :user 2})
@@ -671,7 +671,7 @@
                 (p/map #(dataloader app-db-atom))
                 (p/map (fn []
                          (is (= 2 (get-in @app-db-atom [:kv :user])))
-                         (p/promise (fn [resolve reject]
+                         (p/create (fn [resolve reject]
                                       (js/setTimeout resolve 100)))))
                 (p/map (fn []
                          (is (= [1 2 {:id 2 :user 2} {:id 1 :user 1}] @log))
@@ -686,7 +686,7 @@
      (let [d (get-in r [:params :delay])
            v (get-in r [:params :value])]
        
-       (p/promise (fn [resolve reject]
+       (p/create (fn [resolve reject]
                     (js/setTimeout #(resolve v) d)))))
    reqs))
 
@@ -731,7 +731,7 @@
     
 
     (async done
-           (->> (p/promise (fn [resolve _] (js/setTimeout resolve 50)))
+           (->> (p/create (fn [resolve _] (js/setTimeout resolve 50)))
                 (p/map #(dataloader app-db-atom {:invalid-datasources #{"A" "C" "E"}}))
                 (p/map (fn []
                          (let [res (get-in @app-db-atom [:kv :foo])]
@@ -975,7 +975,7 @@
     :loader (map-loader
              (fn [{:keys [params]}]
                (when params
-                 (p/promise (fn [resolve _]
+                 (p/create (fn [resolve _]
                               (js/setTimeout #(resolve {:id 1 :email "konjevic@gmail.com" :first "Mihael" :last "Konjevic"}) 100))))))
     :params (fn [_ {:keys [page id]} _]
               (when (= :user page) id))}

--- a/test/cljs/keechma/toolbox/pipeline_test.cljs
+++ b/test/cljs/keechma/toolbox/pipeline_test.cljs
@@ -14,7 +14,7 @@
 
 (defn delay-pipeline
   ([] (delay-pipeline 10))
-  ([msec] (p/promise (fn [resolve _] (js/setTimeout resolve msec)))))
+  ([msec] (p/create (fn [resolve _] (js/setTimeout resolve msec)))))
 
 (defn fn-returning-value []
   {:baz :qux})
@@ -145,7 +145,7 @@
 (def promise-error (js/Error. "Promise Rejected"))
 
 (defn fn-promise-rejecting []
-  (p/promise (fn [_ reject]
+  (p/create (fn [_ reject]
                (reject promise-error))))
 
 (defn make-fn-promise-rejecting-pipeline-controller [done]


### PR DESCRIPTION
I came across this while trying to run [example-dataloader-graphql](https://github.com/keechma/example-dataloader-graphql) with updated deps.

I tried to run the keechma-toolbox tests to verify this, but haven't yet figured out how to do that. Adding instructions about how to run the tests to the README would be a good improvement.

With these changes, `example-dataloader-graphql` works for me.

Changes:
- `p/promise` -> `p/create` for `(fn [resolve reject] ...)` as argument
- removed `on-cancel` handling
  - existing code sometimes included a third arg for the constructor fn: `on-cancel` and checked if it was a function before using it
  - looking at the promesa 1.8.1 source code it looks to me like this may always have been `nil` in the past
  - if it was actually used, I'm not sure how to support it using the current promesa API.